### PR TITLE
error handling corrected for ejemplo.js

### DIFF
--- a/ejemplo/package.json
+++ b/ejemplo/package.json
@@ -1,10 +1,11 @@
 {
-    "name": "ejemplo",
-    "version": "1.1.0",
-    "dependencies": {
-		"todo-pago":"1.1.0",
+  "name": "ejemplo",
+  "version": "1.1.0",
+  "dependencies": {
+    "node-rest-client": "1.5.1",
+    "promise": "^8.0.3",
     "soap": "0.5.1",
-  "xml2js": "0.4.10",
-  "node-rest-client": "1.5.1"
-    }
+    "todo-pago": "1.1.0",
+    "xml2js": "0.4.10"
+  }
 }

--- a/lib/todo-pago.js
+++ b/lib/todo-pago.js
@@ -129,9 +129,16 @@ module.exports = {
             var parseString = require('xml2js').parseString;
             parseString(aux, function(err, result) {
 
-                ret = result.OperationsColections.Operations;
-                if (ret === undefined) {
-                    if (result.OperationsColections.Status === undefined) {
+                function validar(fn) {
+                    try {
+                        return fn();
+                    } catch (e) {
+                        return undefined;
+                    }
+                }
+
+                if (validar( () => result.OperationsColections.Operations ) === undefined) {
+                    if (validar( ()=> result.OperationsColections.Status ) === undefined) {
                         ret = {
                             "Status": "No hay estado para esa operacion"
                         };
@@ -139,8 +146,8 @@ module.exports = {
                         ret = {};
                         err = result.OperationsColections.Status;
                     }
-
                 }
+                
                 callback(ret, err);
             });
         });


### PR DESCRIPTION
El siguiente error al ejecutar la funcion exampleGetStatus() en el archivo ejemplo.js:

TypeError: Cannot read property 'Operations' of undefined

para solucionarlo se agrego una funcion con el bloque try..catch (una de las formas para solucionar este error).
Parece ser que los argumentos pasados al get status no devolvia operaciones.

Ademas se agrego el modulo 'promise' al package.json ya que requeria esta dependencia para funcionar.

Espero respuesta! 