### PR TITLE
ejemplo.js error handle

### DIFF
--- a/ejemplo/package.json
+++ b/ejemplo/package.json
@@ -1,10 +1,11 @@
 {
-    "name": "ejemplo",
-    "version": "1.1.0",
-    "dependencies": {
-		"todo-pago":"1.1.0",
+  "name": "ejemplo",
+  "version": "1.1.0",
+  "dependencies": {
+    "node-rest-client": "1.5.1",
+    "promise": "^8.0.3",
     "soap": "0.5.1",
-  "xml2js": "0.4.10",
-  "node-rest-client": "1.5.1"
-    }
+    "todo-pago": "1.1.0",
+    "xml2js": "0.4.10"
+  }
 }

--- a/lib/todo-pago.js
+++ b/lib/todo-pago.js
@@ -192,22 +192,36 @@ module.exports = {
 
         restClient.get(endpoint[options.endpoint] + "t/1.2/" + restAppend + "Operations/GetByRangeDateTime/MERCHANT/" + parameters["MERCHANT"] + "/STARTDATE/" + querystring.escape(parameters["STARTDATE"]) + "/ENDDATE/" + querystring.escape(parameters["ENDDATE"]) + "/PAGENUMBER/" + parameters["PAGENUMBER"], args, function(data, response) {
             var aux = data.toString('utf-8');
-	    var json = JSON.parse(aux);
 
-	var err = null;
-                ret = json.OperationsColections.Operations;
-                if (ret === undefined) {
-                    if (json.OperationsColections.Status === undefined) {
-                        ret = {
-                            "Status": "No hay estado para esa operacion"
-                        };
-                    } else {
-                        ret = {};
-                        err = json.OperationsColections.Status;
-                    }
+            if (aux.indexOf('<!DOCTYPE HTML') !== -1) { // Si la respuesta de data empieza con <!DOCTYPE HTML significa que hay un error de proxy
+                aux = '{}'; // Devolvemos un string tipo objeto vacio
+            }
 
+            var json = JSON.parse(aux);
+
+            // Error handle 2
+            function validar(fn) {
+                try {
+                    return fn();
+                } catch (e) {
+                    return undefined;
                 }
-                callback(ret, err);
+            }
+	       
+	        var err = null;
+                
+            if(validar( () => result.OperationsColections.Operations ) === undefined){
+                if (validar( ()=> result.OperationsColections.Status ) === undefined) {
+                    ret = {
+                        "Status": "No hay estado para esa operacion"
+                    };
+                } else {
+                    ret = {};
+                    err = json.OperationsColections.Status;
+                }
+
+            }
+            callback(ret, err);
             });
     },
 

--- a/lib/todo-pago.js
+++ b/lib/todo-pago.js
@@ -129,9 +129,16 @@ module.exports = {
             var parseString = require('xml2js').parseString;
             parseString(aux, function(err, result) {
 
-                ret = result.OperationsColections.Operations;
-                if (ret === undefined) {
-                    if (result.OperationsColections.Status === undefined) {
+                function validar(fn) {
+                    try {
+                        return fn();
+                    } catch (e) {
+                        return undefined;
+                    }
+                }
+
+                if (validar( () => result.OperationsColections.Operations ) === undefined) {
+                    if (validar( ()=> result.OperationsColections.Status ) === undefined) {
                         ret = {
                             "Status": "No hay estado para esa operacion"
                         };
@@ -139,8 +146,8 @@ module.exports = {
                         ret = {};
                         err = result.OperationsColections.Status;
                     }
-
                 }
+                
                 callback(ret, err);
             });
         });


### PR DESCRIPTION
Al no obtener resultado la función exampleGetStatus() daba el siguiente error:

Cannot read property Operations of undefined.

Por eso se modifico el archivo todo-pago.js con una función que pasa la variable a un bloque try..catch para que no surja el error.

Se corrigió lo mismo para la funcion exampleGetByRangeDateTime(); . En esta función también se corrigió que se obtenía un archivo html desde la respuesta por lo tanto JSON.parse daba error. Para esto si la data devuelta por la función contiene el string "<!DOCTYPE HTML" esto devuelve un string tipo json "{}" vacio para que se siga ejecutando la función

Y se agrego el modulo promise al package.json del ejemplo (modulo requerido)